### PR TITLE
Fix building with pacman>=5.0

### DIFF
--- a/thea-the-awakening/PKGBUILD
+++ b/thea-the-awakening/PKGBUILD
@@ -26,11 +26,10 @@ package() {
   install -d "${pkgdir}/usr/share/applications"
   install -d "${pkgdir}/usr/bin"
 
-  arch=`uname -m`
-  if [ $arch == i686 ];then
+  if [ $CARCH == i686 ];then
   	    install -m755 "${srcdir}/Thea.x86" "${pkgdir}/opt/games/${_pkgname}"
         ln -s "/opt/games/${_pkgname}/Thea.x86" "${pkgdir}/usr/bin/${_pkgname}"
-  elif [ $arch == x86_64 ];then
+  elif [ $CARCH == x86_64 ];then
   	    install -m755 "${srcdir}/Thea.x86_64" "${pkgdir}/opt/games/${_pkgname}"
         ln -s "/opt/games/${_pkgname}/Thea.x86_64" "${pkgdir}/usr/bin/${_pkgname}"
   fi


### PR DESCRIPTION
Was refusing to build, because:

```
==> ERROR: arch should be an array
```

And as a bonus: you have correct architecture detection now :)
